### PR TITLE
Extracted scores probabilities from scores structs

### DIFF
--- a/scores.go
+++ b/scores.go
@@ -6,35 +6,44 @@ type ScoreError struct {
 	Type    string `json:"type"`
 }
 
+// ScoreArticleQualityProbability ores the scores values for article quality scores
+type ScoreArticleQualityProbability struct {
+	B     float64 `json:"B"`
+	C     float64 `json:"C"`
+	FA    float64 `json:"FA"`
+	GA    float64 `json:"GA"`
+	Start float64 `json:"Start"`
+	Stub  float64 `json:"Stub"`
+}
+
 // ScoreArticleQuality quality of the article model score
 type ScoreArticleQuality struct {
-	Prediction  string `json:"prediction"`
-	Probability struct {
-		B     float64 `json:"B"`
-		C     float64 `json:"C"`
-		FA    float64 `json:"FA"`
-		GA    float64 `json:"GA"`
-		Start float64 `json:"Start"`
-		Stub  float64 `json:"Stub"`
-	} `json:"probability"`
+	Prediction  string                         `json:"prediction"`
+	Probability ScoreArticleQualityProbability `json:"probability"`
+}
+
+// ScoreDamagingProbability stores the scores values for damaging scores
+type ScoreDamagingProbability struct {
+	False float64 `json:"false"`
+	True  float64 `json:"true"`
 }
 
 // ScoreDamaging score to determine if revision is damaging
 type ScoreDamaging struct {
-	Prediction  bool `json:"prediction"`
-	Probability struct {
-		False float64 `json:"false"`
-		True  float64 `json:"true"`
-	} `json:"probability"`
+	Prediction  bool                     `json:"prediction"`
+	Probability ScoreDamagingProbability `json:"probability"`
+}
+
+// ScoreGoodFaithProbability stores the scores values for goodfaith scores
+type ScoreGoodFaithProbability struct {
+	False float64 `json:"false"`
+	True  float64 `json:"true"`
 }
 
 // ScoreGoodFaith revision good faith score
 type ScoreGoodFaith struct {
-	Prediction  bool `json:"prediction"`
-	Probability struct {
-		False float64 `json:"false"`
-		True  float64 `json:"true"`
-	} `json:"probability"`
+	Prediction  bool                      `json:"prediction"`
+	Probability ScoreGoodFaithProbability `json:"probability"`
 }
 
 // Scores ORES API response type


### PR DESCRIPTION
Having the scores probabilities declared as in-line structs makes it difficult to reuse the library in a context different from unmarshaling the ORES API response (when testing, for example).

With this change, we can build instances for `ScoreArticleQuality`, `ScoreDamaging`, and `ScoreGoodFaith` structures without having to re declare the inline probabilities structures.

We would pass from this:
```go
goodFaith := &ores.ScoreGoodFaith{
	Prediction: true,
	Probability: struct{False float64 "json:\"false\""; True float64 "json:\"true\""}{
		True: 0.9,
		False: 0.1,
	},
}
```

To this:
```go
goodFaith := &ores.ScoreGoodFaith{
	Prediction: true,
	Probability: ores.ScoreGoodFaithProbability{
		True: 0.9,
		False: 0.1,
	},
}
```
